### PR TITLE
数字始まりの id 属性値を修正する

### DIFF
--- a/src/parenting-who/index.njk
+++ b/src/parenting-who/index.njk
@@ -30,22 +30,22 @@ date: Last Modified
       <div>目次</div>
       <ol role="directory">
         <li>
-          <a href="#1-One-on-One-Time">『1対1の時間』</a>
+          <a href="#One-on-One-Time">『1対1の時間』</a>
         </li>
         <li>
-          <a href="#2-Keeping-It-Positive">『肯定的でいましょう』</a>
+          <a href="#Keeping-It-Positive">『肯定的でいましょう』</a>
         </li>
         <li>
-          <a href="#3-Structure-Up">『新しい日課を作る』</a>
+          <a href="#Structure-Up">『新しい日課を作る』</a>
         </li>
         <li>
-          <a href="#4-Bad-Behavior">『悪い行い』</a>
+          <a href="#Bad-Behavior">『悪い行い』</a>
         </li>
         <li>
-          <a href="#5-Keep-Calm-and-Manage-Stress">『焦らずにストレスマネジメント』</a>
+          <a href="#Keep-Calm-and-Manage-Stress">『焦らずにストレスマネジメント』</a>
         </li>
         <li>
-          <a href="#6-Talking-about-COVID-19">『新型コロナウイルスについて話をする』</a>
+          <a href="#Talking-about-COVID-19">『新型コロナウイルスについて話をする』</a>
         </li>
       </ol>
 
@@ -57,11 +57,11 @@ date: Last Modified
         <li>一部の文章について、原典の意図を分かりやすく伝えるために日本向けに付け足している箇所があります。</li>
       </ul>
 
-      <section id="1-One-on-One-Time">
+      <section id="One-on-One-Time">
         <img src="./illustrations/01_00_yellow.jpg" alt="イラスト：子どもの背後に母親が寄り添い、肩に手を添えている。二人とも微笑んでいる。" decoding="async"/>
         <header class="heading-anchor">
           <h2>1.『1対1の時間』</h2>
-          <a href="#1-One-on-One-Time" class="heading-anchor__link">
+          <a href="#One-on-One-Time" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>仕事にいけない、学校が閉まる、お金はどうなるのか…など、ストレスを感じたり困惑したりするのは当たり前のことです。あなただけではありません。</p>
@@ -141,11 +141,11 @@ date: Last Modified
         </div>
       </section>
 
-      <section id="2-Keeping-It-Positive">
+      <section id="Keeping-It-Positive">
         <img src="./illustrations/02_00_yellow.jpg" alt="イラスト：女の子と母親がお互いに明るく話をしている。" loading="lazy"/>
         <header class="heading-anchor">
           <h2>2.『肯定的でいましょう』</h2>
-          <a href="#2-Keeping-It-Positive" class="heading-anchor__link">
+          <a href="#Keeping-It-Positive" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>
@@ -207,11 +207,11 @@ date: Last Modified
         </section>
       </section>
 
-      <section id="3-Structure-Up">
+      <section id="Structure-Up">
         <img src="./illustrations/03_00_yellow.jpg" alt="イラスト：行先を指差しながら、母親の手を引く子ども。二人とも楽しそうにしている。" loading="lazy"/>
         <header class="heading-anchor">
           <h2>3.『新しい日課を作る』</h2>
-          <a href="#3-Structure-Up" class="heading-anchor__link">
+          <a href="#Structure-Up" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>新型コロナウイルスによって、仕事、家庭、学校での日常が奪われてしまいました。これは子どもにもあなたにもとても厳しい現実です。新しく、家での日課を作ってみてはいかがでしょうか。</p>
@@ -275,11 +275,11 @@ date: Last Modified
         </div>
       </section>
 
-      <section id="4-Bad-Behavior">
+      <section id="Bad-Behavior">
         <img src="./illustrations/04_00_yellow.jpg" alt="イラスト：子どもが腕を組み、いろいろなモヤモヤを抱えて浮かない表情をたたえている。" loading="lazy"/>
         <header class="heading-anchor">
           <h2>4.『悪い行い』</h2>
-          <a href="#4-Bad-Behavior" class="heading-anchor__link">
+          <a href="#Bad-Behavior" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>子どもは誰しも悪い行いをしてしまう日はあります。疲れていたり、お腹が空いていたり、怖がっていたり、親から自立していく中では良くあることです。ずっと家に閉じこもっているとそんな子ども達に頭を悩ませてしまうこともあります。</p>
@@ -339,11 +339,11 @@ date: Last Modified
         </ul>
       </section>
 
-      <section id="5-Keep-Calm-and-Manage-Stress">
+      <section id="Keep-Calm-and-Manage-Stress">
         <img src="./illustrations/05_00_yellow.jpg" alt="イラスト：母親が目を閉じ、リラックスした様子で仰向けに横たわっている。" loading="lazy"/>
         <header class="heading-anchor">
           <h2>5.『焦らずにストレスマネジメント』</h2>
-          <a href="#5-Keep-Calm-and-Manage-Stress" class="heading-anchor__link">
+          <a href="#Keep-Calm-and-Manage-Stress" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>今はとてもストレスが溜まりやすい時期です。子どものサポートができるように、まずは自分を大事にしましょう。</p>
@@ -433,11 +433,11 @@ date: Last Modified
         </section>
       </section>
 
-      <section id="6-Talking-about-COVID-19">
+      <section id="Talking-about-COVID-19">
         <img src="./illustrations/06_00_yellow.jpg" alt="イラスト：父親が、子どもの背中に手を沿えながら話しかけている。" loading="lazy"/>
         <header class="heading-anchor">
           <h2>6.『新型コロナウイルスについて話をする』</h2>
-          <a href="#6-Talking-about-COVID-19" class="heading-anchor__link">
+          <a href="#Talking-about-COVID-19" class="heading-anchor__link">
             <span class="visually-hidden">このセクションへのリンク</span></a>
         </header>
         <p>


### PR DESCRIPTION
https://momdo.github.io/css2/syndata.html#characters

> CSSにおいて、（要素名、クラス、およびセレクター内のIDを含む）識別子は、（中略）数字、2つのハイフン、ハイフンの直後の数字で開始できない。

数字始まりの値は id 属性値に利用してはいけなかったのでこれを修正しました。

確認お願いいたします。