### PR TITLE
Google AnalyticsとCookieについてのセクションを追加する

### DIFF
--- a/src/parenting-who/index.njk
+++ b/src/parenting-who/index.njk
@@ -585,6 +585,23 @@ date: Last Modified
           <li>本記事について、疑義や誤りのご指摘などは、info@polaar.jp までお問い合せください。（個人での対応となりますので、すべてに対応できない可能性があります。あらかじめご了承ください）</li>
         </ul>
       </section>
+      <section id="Analytics-and-cookie">
+        <header class="heading-anchor">
+          <h2>Google AnalyticsとCookieについて</h2>
+          <a href="#Analytics-and-cookie" class="heading-anchor__link">
+            <span class="visually-hidden">このセクションへのリンク</span></a>
+        </header>
+        <p>当サイトではコンテンツの維持運営のためGoogle Analyticsを利用しています。</p>
+        <p>Google Analyticsは、当サイトが発行するCookieを利用して、アクセス状況、トラフィック、閲覧環境、およびIPアドレスなど個人の特定が可能なごく一部の情報を収集しています。</p>
+        <p>Cookieの利用に関してはGoogleのプライバシーポリシーと規約に基づいています。</p>
+        <p>取得したデータはWebサイト利用状況の分析、サイト運営者へのレポートの作成、その他のサービスの提供に関わる目的に限り、これを使用します。</p>
+        <p>Google Analyticsの利用規約及びプライバシーポリシーに関する説明については、Google Analyticsのサイトをご覧ください。</p>
+        <ul>
+          <li><a href="https://marketingplatform.google.com/about/analytics/terms/jp/" rel="noopener" target="_blank">Google Analytics利用規約</a>
+          <li><a href="https://policies.google.com/privacy?hl=ja" rel="noopener" target="_blank">Googleのプライバシーポリシー</a>
+          <li><a href="https://support.google.com/analytics/answer/6004245?hl=ja" rel="noopener" target="_blank">Google Analyticsのデータの保護について</a>
+        </ul>
+      </section>
       <section id="Credit">
         <header class="heading-anchor">
           <h2>制作・翻訳</h2>


### PR DESCRIPTION
Google Analyticsと（それに付随してCookieの利用）についてのセクションを追加しました。
https://deploy-preview-22--covid-19-act.netlify.com/parenting-who/#Analytics-and-cookie

確認お願いいたします。