### PR TITLE
外部リンクについた target 属性を削除する

### DIFF
--- a/src/parenting-who/index.njk
+++ b/src/parenting-who/index.njk
@@ -719,11 +719,11 @@ date: Last Modified
         <p>Google Analyticsの利用規約及びプライバシーポリシーに関する説明については、Google Analyticsのサイトをご覧ください。</p>
         <ul>
           <li>
-            <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" rel="noopener" target="_blank">Google Analytics利用規約</a>
+            <a href="https://marketingplatform.google.com/about/analytics/terms/jp/">Google Analytics利用規約</a>
           <li>
-            <a href="https://policies.google.com/privacy?hl=ja" rel="noopener" target="_blank">Googleのプライバシーポリシー</a>
+            <a href="https://policies.google.com/privacy?hl=ja">Googleのプライバシーポリシー</a>
           <li>
-            <a href="https://support.google.com/analytics/answer/6004245?hl=ja" rel="noopener" target="_blank">Google Analyticsのデータの保護について</a>
+            <a href="https://support.google.com/analytics/answer/6004245?hl=ja">Google Analyticsのデータの保護について</a>
         </ul>
       </section>
       <section id="Credit">

--- a/src/parenting-who/index.njk
+++ b/src/parenting-who/index.njk
@@ -71,7 +71,7 @@ date: Last Modified
       <p>そんな保護者の方々のために、WHO（世界保健機関）が全世界の保護者へ向けて、今この状況における子どもとの付き合い方についてアドバイスを発信しています。</p>
 
       <ul class="note">
-        <li>本記事の公開時点までにWHO『<a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public/healthy-parenting" lang="en">Healthy Parenting</a>』にて公開されている、6枚のポスター（PDF）に基づき翻訳しています。</li>
+        <li>本記事の公開時点までにWHO『<a lang="en" href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public/healthy-parenting">Healthy Parenting</a>』にて公開されている、6枚のポスター（PDF）に基づき翻訳しています。</li>
         <li>一部の文章について、原典の意図を分かりやすく伝えるために日本向けに付け足している箇所があります。</li>
       </ul>
 
@@ -620,10 +620,10 @@ date: Last Modified
           </header>
           <p>全てが本当の話とは限りません。信頼性の高いウェブサイトを使いましょう：</p>
           <p>
-            <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public" lang="en">Advice
+            <a lang="en" href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public">Advice
             for publich</a>
           あるいは
-          <a href="https://www.unicef.org/coronavirus/covid-19" lang="en">Page Coronavirus disease (COVID-19)</a>
+          <a lang="en" href="https://www.unicef.org/coronavirus/covid-19">Page Coronavirus disease (COVID-19)</a>
           </p>
         これらは<abbr title="World Health Organization">WHO</abbr>とUNICEFによる内容です。
       </section>


### PR DESCRIPTION
#25 でアイコンの議論が進んでいますが、外部リンクを別タブで開かない方向に統一するのは決まっているので、それだけ先にPRsします。