### PR TITLE
rewrite-credit

### DIFF
--- a/src/parenting-who/index.njk
+++ b/src/parenting-who/index.njk
@@ -744,7 +744,7 @@ date: Last Modified
           <dd>関口 裕</dd>
           <dd>大橋 正司</dd>
           <dd>林 敬子</dd>
-          <dt>翻訳協力</dt>
+          <dt>協力</dt>
           <dd>園田 正樹</dd>
           <dd>園田 美奈</dd>
           <dt>イラストレーション</dt>


### PR DESCRIPTION
@masuP9 @oti @uknmr 
クレジットの「翻訳協力」が主たる翻訳者であるという誤解が一部で発生したので、「協力」に変更。
（園田さんたちは翻訳の発注を仲介してくれただけなので）